### PR TITLE
Add plugin lifecycle logs and refine PluginMain

### DIFF
--- a/app/src/main/java/com/example/host/MainActivity.kt
+++ b/app/src/main/java/com/example/host/MainActivity.kt
@@ -1,18 +1,17 @@
 // Host: com/example/host/MainActivity.kt
 package com.example.host
 
-import android.Manifest
 import android.content.Intent
-import android.content.pm.PackageManager
-import android.os.Build
 import android.os.Bundle
+import android.util.Log
+import android.widget.TextView
 import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.content.ContextCompat
 import java.io.File
 import java.io.FileOutputStream
 
 class MainActivity : ComponentActivity() {
+    companion object { private const val TAG = "MainActivity" }
 
     private val requestPerm = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
@@ -21,6 +20,8 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        Log.d(TAG, "onCreate")
 
         // 1) 将 assets 里的 plugin.apk 拷贝到内部存储（避免分区存储麻烦）
         val pluginApk = File(filesDir, "plugin.apk")
@@ -32,9 +33,17 @@ class MainActivity : ComponentActivity() {
 
         // 2) 加载插件
         PluginManager.load(this, pluginApk.absolutePath)
+        Log.d(TAG, "Plugin loaded")
+
+        // 显示插件信息
+        val infoText = PluginManager.pluginInfo?.let {
+            "Plugin: ${it.packageName}\nVersion: ${it.versionName ?: "unknown"} (${it.versionCode})"
+        } ?: "插件信息读取失败"
+        findViewById<TextView>(R.id.tvInfo)?.text = infoText
 
         // 3) 启动 ProxyActivity，并指定插件类名（完整类名）
         findViewById<android.view.View>(R.id.btnLaunch)?.setOnClickListener {
+            Log.d(TAG, "Launch plugin")
             val intent = Intent(this, ProxyActivity::class.java).apply {
                 putExtra("plugin_class", "com.example.plugin.PluginMain")
             }

--- a/app/src/main/java/com/example/host/PluginInfo.kt
+++ b/app/src/main/java/com/example/host/PluginInfo.kt
@@ -1,0 +1,7 @@
+package com.example.host
+
+data class PluginInfo(
+    val packageName: String,
+    val versionName: String?,
+    val versionCode: Long
+)

--- a/app/src/main/java/com/example/host/ProxyActivity.kt
+++ b/app/src/main/java/com/example/host/ProxyActivity.kt
@@ -2,15 +2,19 @@ package com.example.host
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.util.TypedValue
 import android.view.Window
 import androidx.appcompat.app.AppCompatActivity
 import com.example.plugin_api.IPluginActivity
 
 class ProxyActivity : AppCompatActivity() {
+    companion object { private const val TAG = "ProxyActivity" }
     private var plugin: IPluginActivity? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        Log.d(TAG, "onCreate")
+
         // 先给稳定的 AppCompat 主题，防止崩
         setTheme(androidx.appcompat.R.style.Theme_AppCompat_DayNight_NoActionBar)
         supportRequestWindowFeature(Window.FEATURE_NO_TITLE)
@@ -27,9 +31,11 @@ class ProxyActivity : AppCompatActivity() {
         val cl = PluginManager.classLoader ?: error("Plugin not loaded")
         val instance =
             cl.loadClass(pluginClass).getDeclaredConstructor().newInstance() as IPluginActivity
+        Log.d(TAG, "Loaded plugin class: $pluginClass")
 
         plugin = instance
         instance.attach(this)
+        Log.d(TAG, "Plugin attached")
         instance.onCreate(savedInstanceState)
     }
 
@@ -46,13 +52,34 @@ class ProxyActivity : AppCompatActivity() {
     override fun getAssets() = PluginManager.assets ?: super.getAssets()
     override fun getResources() = PluginManager.resources ?: super.getResources()
 
-    override fun onStart() { super.onStart(); plugin?.onStart() }
-    override fun onResume() { super.onResume(); plugin?.onResume() }
-    override fun onPause() { plugin?.onPause(); super.onPause() }
-    override fun onStop() { plugin?.onStop(); super.onStop() }
-    override fun onDestroy() { plugin?.onDestroy(); super.onDestroy() }
+    override fun onStart() {
+        super.onStart()
+        Log.d(TAG, "onStart")
+        plugin?.onStart()
+    }
+    override fun onResume() {
+        super.onResume()
+        Log.d(TAG, "onResume")
+        plugin?.onResume()
+    }
+    override fun onPause() {
+        Log.d(TAG, "onPause")
+        plugin?.onPause()
+        super.onPause()
+    }
+    override fun onStop() {
+        Log.d(TAG, "onStop")
+        plugin?.onStop()
+        super.onStop()
+    }
+    override fun onDestroy() {
+        Log.d(TAG, "onDestroy")
+        plugin?.onDestroy()
+        super.onDestroy()
+    }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        Log.d(TAG, "onActivityResult: req=$requestCode res=$resultCode")
         plugin?.onActivityResult(requestCode, resultCode, data)
         super.onActivityResult(requestCode, resultCode, data)
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,12 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <TextView
+        android:id="@+id/tvInfo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingBottom="16dp"/>
+
     <Button
         android:id="@+id/btnLaunch"
         android:text="启动插件界面"

--- a/plugin/src/main/java/com/example/plugin/PluginMain.kt
+++ b/plugin/src/main/java/com/example/plugin/PluginMain.kt
@@ -4,18 +4,22 @@ package com.example.plugin
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.widget.Button
 import android.widget.TextView
 import com.example.plugin_api.IPluginActivity
 
 class PluginMain : IPluginActivity {
+    companion object { private const val TAG = "PluginMain" }
     private lateinit var host: Activity
 
     override fun attach(hostActivity: Activity) {
-        this.host = hostActivity
+        host = hostActivity
+        Log.d(TAG, "attach: $hostActivity")
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        Log.d(TAG, "onCreate")
         // 直接用插件 R；宿主 ProxyActivity 已把资源环境切到插件
         host.setContentView(R.layout.activity_plugin)
 
@@ -24,14 +28,17 @@ class PluginMain : IPluginActivity {
 
         tv?.text = "这是插件里的界面（来自 plugin.apk 的资源）"
         btn?.setOnClickListener {
+            Log.d(TAG, "button clicked")
             android.widget.Toast.makeText(host, "Plugin 按钮点击", android.widget.Toast.LENGTH_SHORT).show()
         }
     }
 
-    override fun onStart() {}
-    override fun onResume() {}
-    override fun onPause() {}
-    override fun onStop() {}
-    override fun onDestroy() {}
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {}
+    override fun onStart() { Log.d(TAG, "onStart") }
+    override fun onResume() { Log.d(TAG, "onResume") }
+    override fun onPause() { Log.d(TAG, "onPause") }
+    override fun onStop() { Log.d(TAG, "onStop") }
+    override fun onDestroy() { Log.d(TAG, "onDestroy") }
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        Log.d(TAG, "onActivityResult: req=$requestCode res=$resultCode")
+    }
 }


### PR DESCRIPTION
## Summary
- add log tags across host for clearer call flow
- log lifecycle events and clicks in plugin `PluginMain`
- tighten plugin loading with detailed progress logging

## Testing
- `bash ./gradlew help`
- `bash ./gradlew app:compileDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895bf5bd5988326889017bc83626ad2